### PR TITLE
Use pngquant-bin to avoid local OS pngquant requirement

### DIFF
--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -1,6 +1,7 @@
 var childProcess = require('child_process'),
     Stream = require('stream').Stream,
-    util = require('util');
+    util = require('util'),
+    binPath = require('pngquant-bin').path;
 
 function PngQuant(pngQuantArgs) {
     Stream.call(this);
@@ -10,8 +11,7 @@ function PngQuant(pngQuantArgs) {
     }
 
     this.writable = this.readable = true;
-
-    this.pngQuantProcess = childProcess.spawn('pngquant', pngQuantArgs);
+    this.pngQuantProcess = childProcess.spawn(binPath, pngQuantArgs);
 
     this.hasEnded = false;
     this.seenDataOnStdout = false;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "directories": {
         "test": "test"
     },
-    "dependencies": {},
+    "dependencies": {
+        "pngquant-bin": "=0.1.2"
+    },
     "devDependencies": {
         "mocha": "=1.7.3",
         "expect.js": "=0.2.0"


### PR DESCRIPTION
This should eliminate the requirement that the user has already installed pngquant globally.

Tested in Linux. The author is working on MacOS, so that should work as well. Haven't tested in Windows yet.
