### PR TITLE
Bump pngquant-bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "pngquant-bin": "=0.1.2"
+    "pngquant-bin": "=0.1.7"
   },
   "devDependencies": {
     "mocha": "=1.7.3",


### PR DESCRIPTION
pngquant-bin 0.1.2 uses DOS line endings which causes errors on OS X when trying
to run it:

```
./node_modules/.../pngquant/node_modules/.bin/pngquant
env: node\r: No such file or directory
```
