### PR TITLE
Added error handler for stdin and stdout.

### DIFF
--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -38,6 +38,8 @@ PngQuant.prototype.write = function (chunk) {
     if (!this.pngQuantProcess) {
         this.pngQuantProcess = childProcess.spawn(binPath, this.pngQuantArgs);
         this.pngQuantProcess.on('error', this._reportError.bind(this));
+        this.pngQuantProcess.stdin.on('error', this._reportError.bind(this));
+        this.pngQuantProcess.stdout.on('error', this._reportError.bind(this));
 
         this.pngQuantProcess.stderr.on('data', function (data) {
             if (!this.hasEnded) {


### PR DESCRIPTION
I have unhandled stream errors in my tests recently. Something to do with concurrency, the PNG is deleted just before or while launching `pngquant`, which breaks the whole test suite because the error isn't treatable.

This patch properly adds an error handler on the process' `stdin` and `stdout`, making these kind of errors treatable for the caller.
