### PR TITLE
Added possibility to set binary path of pngquant manually

### DIFF
--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -22,6 +22,11 @@ function PngQuant(pngQuantArgs) {
 util.inherits(PngQuant, Stream);
 
 PngQuant.getBinaryPath = memoizeAsync(function (cb) {
+    if(this.binaryPath !== undefined) {
+        cb(this.binaryPath);
+        return;
+    }
+
     which('pngquant', function (err, pngQuantBinaryPath) {
         if (err) {
             pngQuantBinaryPath = require('pngquant-bin');
@@ -33,6 +38,10 @@ PngQuant.getBinaryPath = memoizeAsync(function (cb) {
         }
     });
 });
+
+PngQuant.setBinaryPath = function(binaryPath) {
+    this.binaryPath = binaryPath;
+};
 
 PngQuant.prototype._error = function (err) {
     if (!this.hasEnded) {

--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -23,7 +23,7 @@ util.inherits(PngQuant, Stream);
 
 PngQuant.getBinaryPath = memoizeAsync(function (cb) {
     if(this.binaryPath !== undefined) {
-        cb(this.binaryPath);
+        cb(null, this.binaryPath);
         return;
     }
 

--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -23,7 +23,9 @@ util.inherits(PngQuant, Stream);
 
 PngQuant.getBinaryPath = memoizeAsync(function (cb) {
     if(this.binaryPath !== undefined) {
-        cb(null, this.binaryPath);
+        setTimeout(function() {
+            cb(null, this.binaryPath);
+        }, 0);
         return;
     }
 

--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -1,3 +1,4 @@
+/*jshint node: true */
 var childProcess = require('child_process'),
     Stream = require('stream').Stream,
     util = require('util'),

--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -23,9 +23,9 @@ util.inherits(PngQuant, Stream);
 
 PngQuant.getBinaryPath = memoizeAsync(function (cb) {
     if(this.binaryPath !== undefined) {
-        setTimeout(function() {
+        setImmediate(function() {
             cb(null, this.binaryPath);
-        }, 0);
+        });
         return;
     }
 


### PR DESCRIPTION
Added possibility to set binary path of pngquant manually. Pretty useful when using this tool and if you want to hijack the command line with for instance a Docker container. This would also make it possible to use a specific version (or fork) of pngquant on a system where multiple versions are installed.