### PR TITLE
Hotfix for manual binaryPath

### DIFF
--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -23,9 +23,9 @@ function PngQuant(pngQuantArgs) {
 util.inherits(PngQuant, Stream);
 
 PngQuant.getBinaryPath = memoizeAsync(function (cb) {
-    if(this.binaryPath !== undefined) {
+    if(PngQuant.binaryPath !== undefined) {
         setImmediate(function() {
-            cb(null, this.binaryPath);
+            cb(null, PngQuant.binaryPath);
         });
         return;
     }
@@ -43,7 +43,7 @@ PngQuant.getBinaryPath = memoizeAsync(function (cb) {
 });
 
 PngQuant.setBinaryPath = function(binaryPath) {
-    this.binaryPath = binaryPath;
+    PngQuant.binaryPath = binaryPath;
 };
 
 PngQuant.prototype._error = function (err) {


### PR DESCRIPTION
- fixed problem with this arg

Since the thisarg inside setImmediate is the global scope, I changed all 'this' references that should refer to the PngQuant object, to directly refer to the PngQuant.