### PR TITLE
Add updated options in README usage and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the `pngquant` binary (defaults to `[256]`):
 
 ```javascript
 var PngQuant = require('pngquant'),
-    myPngQuanter = new PngQuant([192, '-ordered']);
+    myPngQuanter = new PngQuant([192, '--quality', '60-80', '--nofs', '-']);
 
 sourceStream.pipe(myPngQuanter).pipe(destinationStream);
 ```

--- a/test/PngQuant.js
+++ b/test/PngQuant.js
@@ -13,11 +13,12 @@ it.skipIf = function (condition) {
 };
 
 describe('PngQuant', function () {
-    it('should produce a smaller file', function () {
+
+    it('should produce a smaller file with lower quality and ordered dithering', function () {
         return expect(
             fs.createReadStream(pathModule.resolve(__dirname, 'purplealpha24bit.png')),
             'when piped through',
-            new PngQuant([128]),
+            new PngQuant([128, '--quality', '60-80', '--nofs']),
             'to yield output satisfying',
             function (resultPngBuffer) {
                 expect(resultPngBuffer.length, 'to be within', 0, 8285);


### PR DESCRIPTION
The last options needs to be a '-' when using any option other than the `colors`, so fixed up the usage example.

There was some confusion for me earlier and also someone else: https://github.com/papandreou/node-pngquant/issues/9