### PR TITLE
Bump pngquest-bin to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "optionalDependencies": {
-    "pngquant-bin": "3.0.0"
+    "pngquant-bin": "3.1.1"
   },
   "devDependencies": {
     "coveralls": "2.11.2",


### PR DESCRIPTION
Upgrades pngquest used by this library from 2.4.0 to 2.7.1.

I'll make a PR later to get pngquest-bin to 2.8.2.