### PR TITLE
Environment variable PNGQUANT_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ http.createServer(function (req, res) {
 Installation
 ------------
 
-Make sure you have node.js and npm installed, and that the `pngquant` binary is in your PATH, then run:
+Make sure you have node.js and npm installed, and that the `pngquant` binary is in your PATH, or set environment variable PNGQUANT_PATH, then run:
 
     npm install pngquant
 

--- a/lib/PngQuant.js
+++ b/lib/PngQuant.js
@@ -30,20 +30,24 @@ PngQuant.getBinaryPath = memoizeAsync(cb => {
     return;
   }
 
-  which('pngquant', (err, pngQuantBinaryPath) => {
-    if (err) {
-      pngQuantBinaryPath = require('pngquant-bin');
-    }
-    if (pngQuantBinaryPath) {
-      cb(null, pngQuantBinaryPath);
-    } else {
-      cb(
-        new Error(
-          'No pngquant binary in PATH and pngquant-bin does not provide a pre-built binary for your architecture'
-        )
-      );
-    }
-  });
+  if (process.env.PNGQUANT_PATH) {
+    cb(null, process.env.PNGQUANT_PATH);
+  } else {
+    which('pngquant', (err, pngQuantBinaryPath) => {
+      if (err) {
+        pngQuantBinaryPath = require('pngquant-bin');
+      }
+      if (pngQuantBinaryPath) {
+        cb(null, pngQuantBinaryPath);
+      } else {
+        cb(
+          new Error(
+            'No pngquant binary in PATH and pngquant-bin does not provide a pre-built binary for your architecture'
+          )
+        );
+      }
+    });
+  }
 });
 
 PngQuant.setBinaryPath = binaryPath => {


### PR DESCRIPTION
When you are working with AWS Lambda it is not convenient to modify PATH and to build something during deployment. So I have prebuilt [pngquant for lambda](https://github.com/shopkeep/lambda-pngquant). Editing path would be hacky, so having check for environment variable PNGQUANT_PATH would be quite handy.